### PR TITLE
Improve scheduling with date support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Gradle build output
+**/build/
+# Ignore local Gradle settings
+.gradle/
+local.properties

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine.
+Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. È possibile inserire più contatti e numeri durante la giornata, programmando diverse fasce orarie.
+Gli allarmi vengono impostati con `AlarmManager.setExactAndAllowWhileIdle` per funzionare anche con il telefono bloccato e in modalità doze.
+Il servizio in foreground garantisce l'esecuzione in background e viene ripristinato automaticamente al riavvio.
+L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
 
 ## Build dell'APK
 Per compilare è necessario avere installato l'SDK Android.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Reperibilita
+
+Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
+
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
+
+## Build dell'APK
+È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:
+
+```bash
+cd Reperibilita
+./gradlew assembleDebug
+```
+
+Il file APK verrà generato in `app/build/outputs/apk/debug/`. Copiatelo sul dispositivo e installatelo per effettuare i test.
+
+L'interfaccia permette di selezionare un contatto e aggiungere più intervalli. Per ogni intervallo vengono scelti una data e un'orario di inizio e di fine tramite i relativi selettori. Una volta programmati, gli allarmi vengono ripristinati automaticamente al riavvio del telefono.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
+La funzionalità principale prevede l'attivazione tramite il codice `21+39[numerodidestinazione]#*` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
 
 ## Build dell'APK
 È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `21+39[numerodidestinazione]#*` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
 
 ## Build dell'APK
 È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ cd Reperibilita
 Il file APK verrà generato in `app/build/outputs/apk/debug/`. Copiatelo sul dispositivo e installatelo per effettuare i test.
 
 L'interfaccia permette di selezionare un contatto e aggiungere più intervalli. Per ogni intervallo vengono scelti una data e un'orario di inizio e di fine tramite i relativi selettori. Una volta programmati, gli allarmi vengono ripristinati automaticamente al riavvio del telefono.
+
+È presente inoltre un pulsante "Annulla Programmazione" che rimuove tutte le fasce orarie salvate. Per evitare che Android chiuda l'applicazione in background è consigliato disattivare le ottimizzazioni batteria per "Reperibilità" dalle impostazioni del dispositivo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine.
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `##002#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine.
 Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. È possibile inserire più contatti e numeri durante la giornata, programmando diverse fasce orarie.
 Gli allarmi vengono impostati con `AlarmManager.setExactAndAllowWhileIdle` per funzionare anche con il telefono bloccato e in modalità doze.
 Il servizio in foreground garantisce l'esecuzione in background e viene ripristinato automaticamente al riavvio.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione più chiara degli intervalli programmati.
+La funzionalità principale prevede l'attivazione tramite il codice `21+39[numerodidestinazione]#*` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
 
 ## Build dell'APK
 È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@ Questo repository contiene una semplice app Android (Kotlin) per programmare l'i
 La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
 
 ## Build dell'APK
-È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:
+Per compilare è necessario avere installato l'SDK Android.
+Se Android Studio non individua automaticamente il percorso, create nella radice
+della cartella `Reperibilita` un file `local.properties` con il seguente
+contenuto indicando il percorso del vostro SDK:
+
+```
+sdk.dir=C:\\Percorso\\Android\\sdk
+```
+
+Una volta configurato l'SDK potete compilare usando:
 
 ```bash
 cd Reperibilita

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
 
 ## Build dell'APK
 È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
 
-La funzionalità principale prevede l'attivazione tramite il codice `21+39[numerodidestinazione]#*` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background.
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `#21#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine. Il nome del contatto selezionato viene mostrato nella schermata principale. Più fasce possono essere impostate nello stesso giorno e il servizio resta attivo in background. L'interfaccia utilizza componenti Material per una presentazione più chiara degli intervalli programmati.
 
 ## Build dell'APK
 È necessario Android Studio (o il comando `gradlew`) con un'installazione dell'SDK. Compilare in questo modo:

--- a/Reperibilita/app/build.gradle
+++ b/Reperibilita/app/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.reperibilita"
+        minSdk 23
+        targetSdk 30
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
+}

--- a/Reperibilita/app/proguard-rules.pro
+++ b/Reperibilita/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for Reperibilita

--- a/Reperibilita/app/src/main/AndroidManifest.xml
+++ b/Reperibilita/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"

--- a/Reperibilita/app/src/main/AndroidManifest.xml
+++ b/Reperibilita/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.reperibilita">
+
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="Reperibilità"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Reperibilita">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <receiver android:name=".BootReceiver" android:exported="false" >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <receiver android:name=".AlarmReceiver" android:exported="false" />
+        <service android:name=".ForwardingService"
+            android:foregroundServiceType="phoneCall"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/AlarmReceiver.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/AlarmReceiver.kt
@@ -1,0 +1,25 @@
+package com.example.reperibilita
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_ACTIVATE -> {
+                val number = intent.getStringExtra(EXTRA_NUMBER) ?: return
+                ForwardingService.activate(context, number)
+            }
+            ACTION_DEACTIVATE -> {
+                ForwardingService.deactivate(context)
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_ACTIVATE = "com.example.reperibilita.ACTIVATE"
+        const val ACTION_DEACTIVATE = "com.example.reperibilita.DEACTIVATE"
+        const val EXTRA_NUMBER = "extra_number"
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/BootReceiver.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/BootReceiver.kt
@@ -1,0 +1,13 @@
+package com.example.reperibilita
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            ScheduleManager.restoreAlarms(context)
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -41,7 +41,7 @@ class ForwardingService : Service() {
     }
 
     private fun sendActivationCode(phone: String) {
-        val uri = Uri.parse("tel:**21*+39${'$'}{phone}%23")
+        val uri = Uri.parse("tel:21+39${'$'}{phone}%23%2A")
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -61,7 +61,7 @@ class ForwardingService : Service() {
         }
 
         fun deactivate(context: Context) {
-            val uri = Uri.parse("tel:#21%23")
+            val uri = Uri.parse("tel:%23%23002%23")
             val intent = Intent(Intent.ACTION_CALL, uri)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             context.startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -1,0 +1,67 @@
+package com.example.reperibilita
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class ForwardingService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val phone = intent?.getStringExtra(EXTRA_NUMBER) ?: return START_NOT_STICKY
+        startForeground(NOTIFICATION_ID, createNotification(phone))
+        sendActivationCode(phone)
+        return START_NOT_STICKY
+    }
+
+    private fun createNotification(phone: String): Notification {
+        val channelId = "reperibilita_channel"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Reperibilita", NotificationManager.IMPORTANCE_LOW)
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+        val intent = Intent(this, MainActivity::class.java)
+        val pending = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle("Reperibilità attiva")
+            .setContentText("Inoltro verso $phone")
+            .setSmallIcon(android.R.drawable.stat_sys_phone_call)
+            .setContentIntent(pending)
+            .build()
+    }
+
+    private fun sendActivationCode(phone: String) {
+        val uri = Uri.parse("tel:**21*+39${phone}%23")
+        val intent = Intent(Intent.ACTION_CALL, uri)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 1
+        private const val EXTRA_NUMBER = "extra_number"
+
+        fun activate(context: Context, number: String) {
+            val intent = Intent(context, ForwardingService::class.java)
+            intent.putExtra(EXTRA_NUMBER, number)
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        fun deactivate(context: Context) {
+            val uri = Uri.parse("tel:#21%23")
+            val intent = Intent(Intent.ACTION_CALL, uri)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            context.startActivity(intent)
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -46,6 +46,8 @@ class ForwardingService : Service() {
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
+        stopForeground(true)
+        stopSelf()
     }
 
     companion object {

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -18,13 +18,13 @@ class ForwardingService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val phone = intent?.getStringExtra(EXTRA_NUMBER) ?: return START_NOT_STICKY
-        startForeground(NOTIFICATION_ID, createNotification(phone))
-        sendActivationCode(phone)
+        val phoneNumber = intent?.getStringExtra(EXTRA_NUMBER) ?: return START_NOT_STICKY
+        startForeground(NOTIFICATION_ID, createNotification(phoneNumber))
+        sendActivationCode(phoneNumber)
         return START_NOT_STICKY
     }
 
-    private fun createNotification(phone: String): Notification {
+    private fun createNotification(phoneNumber: String): Notification {
         val channelId = "reperibilita_channel"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(channelId, "Reperibilita", NotificationManager.IMPORTANCE_LOW)
@@ -34,14 +34,14 @@ class ForwardingService : Service() {
         val pending = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         return NotificationCompat.Builder(this, channelId)
             .setContentTitle("Reperibilità attiva")
-            .setContentText("Inoltro verso $phone")
-            .setSmallIcon(android.R.drawable.stat_sys_phone_call)
+            .setContentText("Inoltro verso $phoneNumber")
+            .setSmallIcon(android.R.drawable.sym_call_outgoing)
             .setContentIntent(pending)
             .build()
     }
 
-    private fun sendActivationCode(phone: String) {
-        val uri = Uri.parse("tel:21+39${'$'}{phone}%23%2A")
+    private fun sendActivationCode(phoneNumber: String) {
+        val uri = Uri.parse("tel:21+39${'$'}{phoneNumber}%23%2A")
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -41,7 +41,8 @@ class ForwardingService : Service() {
     }
 
     private fun sendActivationCode(phoneNumber: String) {
-        val uri = Uri.parse("tel:21+39${'$'}{phoneNumber}%23%2A")
+        val ussd = "**21*+39${phoneNumber}#"
+        val uri = Uri.parse("tel:" + Uri.encode(ussd))
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -41,7 +41,7 @@ class ForwardingService : Service() {
     }
 
     private fun sendActivationCode(phone: String) {
-        val uri = Uri.parse("tel:**21*+39${phone}%23")
+        val uri = Uri.parse("tel:21+39${'$'}{phone}%23*")
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -41,7 +41,7 @@ class ForwardingService : Service() {
     }
 
     private fun sendActivationCode(phone: String) {
-        val uri = Uri.parse("tel:21+39${'$'}{phone}%23*")
+        val uri = Uri.parse("tel:**21*+39${'$'}{phone}%23")
         val intent = Intent(Intent.ACTION_CALL, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
@@ -1,0 +1,12 @@
+package com.example.reperibilita
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+data class Interval(val start: Calendar, val end: Calendar) {
+    override fun toString(): String {
+        val fmt = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+        return "${fmt.format(start.time)} - ${fmt.format(end.time)}"
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
@@ -4,9 +4,15 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-data class Interval(val start: Calendar, val end: Calendar) {
+data class Interval(
+    val start: Calendar,
+    val end: Calendar,
+    val number: String,
+    val name: String
+) {
     override fun toString(): String {
         val fmt = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
-        return "${fmt.format(start.time)} - ${fmt.format(end.time)}"
+        val range = "${fmt.format(start.time)} - ${fmt.format(end.time)}"
+        return "$range → $name"
     }
 }

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -116,8 +116,11 @@ class MainActivity : AppCompatActivity() {
                     endTimePicker.addOnPositiveButtonClickListener {
                         end.set(Calendar.HOUR_OF_DAY, endTimePicker.hour)
                         end.set(Calendar.MINUTE, endTimePicker.minute)
-                        intervals.add(Interval(start, end))
-                        updateIntervalsText()
+                        val number = phoneEditText.text.toString()
+                        if (number.isNotBlank()) {
+                            intervals.add(Interval(start, end, number, contactName))
+                            updateIntervalsText()
+                        }
                     }
                     endTimePicker.show(supportFragmentManager, "end_time")
                 }
@@ -129,22 +132,18 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateIntervalsText() {
-        intervalsTextView.text = intervals.joinToString("\n") { "\u2022 ${it}" }
+        intervalsTextView.text = intervals.joinToString("\n") {
+            "\u2022 ${it} (${it.number})"
+        }
     }
 
     private fun schedule() {
-        val number = phoneEditText.text.toString()
-        if (number.isNotBlank() && intervals.isNotEmpty()) {
-            ScheduleManager.schedule(this, intervals, number, contactName)
+        if (intervals.isNotEmpty()) {
+            ScheduleManager.schedule(this, intervals)
         }
     }
 
     private fun loadScheduledData() {
-        ScheduleManager.getScheduledNumber(this)?.let { phoneEditText.setText(it) }
-        ScheduleManager.getScheduledName(this)?.let {
-            contactName = it
-            contactNameTextView.text = it
-        }
         if (ScheduleManager.isEnabled(this)) {
             intervals.clear()
             intervals.addAll(ScheduleManager.getIntervals(this))

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -127,7 +127,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateIntervalsText() {
-        intervalsTextView.text = intervals.joinToString("\n") { it.toString() }
+        intervalsTextView.text = intervals.joinToString("\n") { "\u2022 ${it}" }
     }
 
     private fun schedule() {

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -1,0 +1,137 @@
+package com.example.reperibilita
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import android.provider.ContactsContract
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import com.google.android.material.datepicker.MaterialDatePicker
+import java.util.Calendar
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var phoneEditText: EditText
+    private lateinit var intervalsTextView: TextView
+    private val intervals = mutableListOf<Interval>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        phoneEditText = findViewById(R.id.phoneEditText)
+        intervalsTextView = findViewById(R.id.intervalsTextView)
+        val selectContactButton: Button = findViewById(R.id.selectContactButton)
+        val addIntervalButton: Button = findViewById(R.id.addIntervalButton)
+        val scheduleButton: Button = findViewById(R.id.scheduleButton)
+        val activateButton: Button = findViewById(R.id.activateButton)
+        val deactivateButton: Button = findViewById(R.id.deactivateButton)
+
+        selectContactButton.setOnClickListener { pickContact() }
+        addIntervalButton.setOnClickListener { addInterval() }
+        scheduleButton.setOnClickListener { schedule() }
+        activateButton.setOnClickListener { ForwardingService.activate(this, phoneEditText.text.toString()) }
+        deactivateButton.setOnClickListener { ForwardingService.deactivate(this) }
+
+        requestPermissionsIfNeeded()
+    }
+
+    private fun pickContact() {
+        val intent = Intent(Intent.ACTION_PICK, ContactsContract.CommonDataKinds.Phone.CONTENT_URI)
+        contactResultLauncher.launch(intent)
+    }
+
+    private val contactResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.data?.let { uri ->
+                val number = getPhoneFromUri(uri)
+                phoneEditText.setText(number)
+            }
+        }
+    }
+
+    private fun getPhoneFromUri(uri: Uri): String {
+        var number = ""
+        val cursor = contentResolver.query(uri, null, null, null, null)
+        cursor?.use {
+            if (it.moveToFirst()) {
+                number = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+            }
+        }
+        return number
+    }
+
+    private fun addInterval() {
+        val startDatePicker = MaterialDatePicker.Builder.datePicker()
+            .setTitleText(getString(R.string.select_start_date))
+            .build()
+        startDatePicker.addOnPositiveButtonClickListener { startMillis ->
+            val start = Calendar.getInstance().apply { timeInMillis = startMillis }
+            val startTimePicker = MaterialTimePicker.Builder()
+                .setTimeFormat(TimeFormat.CLOCK_24H)
+                .setTitleText(getString(R.string.select_start_time))
+                .build()
+            startTimePicker.addOnPositiveButtonClickListener {
+                start.set(Calendar.HOUR_OF_DAY, startTimePicker.hour)
+                start.set(Calendar.MINUTE, startTimePicker.minute)
+
+                val endDatePicker = MaterialDatePicker.Builder.datePicker()
+                    .setTitleText(getString(R.string.select_end_date))
+                    .build()
+                endDatePicker.addOnPositiveButtonClickListener { endMillis ->
+                    val end = Calendar.getInstance().apply { timeInMillis = endMillis }
+                    val endTimePicker = MaterialTimePicker.Builder()
+                        .setTimeFormat(TimeFormat.CLOCK_24H)
+                        .setTitleText(getString(R.string.select_end_time))
+                        .build()
+                    endTimePicker.addOnPositiveButtonClickListener {
+                        end.set(Calendar.HOUR_OF_DAY, endTimePicker.hour)
+                        end.set(Calendar.MINUTE, endTimePicker.minute)
+                        intervals.add(Interval(start, end))
+                        updateIntervalsText()
+                    }
+                    endTimePicker.show(supportFragmentManager, "end_time")
+                }
+                endDatePicker.show(supportFragmentManager, "end_date")
+            }
+            startTimePicker.show(supportFragmentManager, "start_time")
+        }
+        startDatePicker.show(supportFragmentManager, "start_date")
+    }
+
+    private fun updateIntervalsText() {
+        intervalsTextView.text = intervals.joinToString("\n") { it.toString() }
+    }
+
+    private fun schedule() {
+        val number = phoneEditText.text.toString()
+        if (number.isNotBlank() && intervals.isNotEmpty()) {
+            ScheduleManager.schedule(this, intervals, number)
+        }
+    }
+
+    private fun requestPermissionsIfNeeded() {
+        val permissions = arrayOf(
+            Manifest.permission.CALL_PHONE,
+            Manifest.permission.READ_CONTACTS
+        )
+        val toRequest = permissions.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (toRequest.isNotEmpty()) {
+            ActivityCompat.requestPermissions(this, toRequest.toTypedArray(), 0)
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -19,11 +19,14 @@ import com.google.android.material.timepicker.TimeFormat
 import com.google.android.material.datepicker.MaterialDatePicker
 import java.util.Calendar
 
+
 class MainActivity : AppCompatActivity() {
 
     private lateinit var phoneEditText: EditText
+    private lateinit var contactNameTextView: TextView
     private lateinit var intervalsTextView: TextView
     private val intervals = mutableListOf<Interval>()
+    private var contactName: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +34,7 @@ class MainActivity : AppCompatActivity() {
 
         phoneEditText = findViewById(R.id.phoneEditText)
         intervalsTextView = findViewById(R.id.intervalsTextView)
+        contactNameTextView = findViewById(R.id.contactNameTextView)
         val selectContactButton: Button = findViewById(R.id.selectContactButton)
         val addIntervalButton: Button = findViewById(R.id.addIntervalButton)
         val scheduleButton: Button = findViewById(R.id.scheduleButton)
@@ -44,6 +48,7 @@ class MainActivity : AppCompatActivity() {
         deactivateButton.setOnClickListener { ForwardingService.deactivate(this) }
 
         requestPermissionsIfNeeded()
+        loadScheduledData()
     }
 
     private fun pickContact() {
@@ -56,21 +61,31 @@ class MainActivity : AppCompatActivity() {
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             result.data?.data?.let { uri ->
-                val number = getPhoneFromUri(uri)
-                phoneEditText.setText(number)
+                queryContact(uri)
             }
         }
     }
 
-    private fun getPhoneFromUri(uri: Uri): String {
-        var number = ""
-        val cursor = contentResolver.query(uri, null, null, null, null)
+    private fun queryContact(uri: Uri) {
+        val cursor = contentResolver.query(
+            uri,
+            arrayOf(
+                ContactsContract.CommonDataKinds.Phone.NUMBER,
+                ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME
+            ),
+            null,
+            null,
+            null
+        )
         cursor?.use {
             if (it.moveToFirst()) {
-                number = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+                val number = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+                val name = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME))
+                phoneEditText.setText(number)
+                contactNameTextView.text = name
+                contactName = name
             }
         }
-        return number
     }
 
     private fun addInterval() {
@@ -118,7 +133,15 @@ class MainActivity : AppCompatActivity() {
     private fun schedule() {
         val number = phoneEditText.text.toString()
         if (number.isNotBlank() && intervals.isNotEmpty()) {
-            ScheduleManager.schedule(this, intervals, number)
+            ScheduleManager.schedule(this, intervals, number, contactName)
+        }
+    }
+
+    private fun loadScheduledData() {
+        ScheduleManager.getScheduledNumber(this)?.let { phoneEditText.setText(it) }
+        ScheduleManager.getScheduledName(this)?.let {
+            contactName = it
+            contactNameTextView.text = it
         }
     }
 

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -40,12 +40,14 @@ class MainActivity : AppCompatActivity() {
         val scheduleButton: Button = findViewById(R.id.scheduleButton)
         val activateButton: Button = findViewById(R.id.activateButton)
         val deactivateButton: Button = findViewById(R.id.deactivateButton)
+        val clearButton: Button = findViewById(R.id.clearScheduleButton)
 
         selectContactButton.setOnClickListener { pickContact() }
         addIntervalButton.setOnClickListener { addInterval() }
         scheduleButton.setOnClickListener { schedule() }
         activateButton.setOnClickListener { ForwardingService.activate(this, phoneEditText.text.toString()) }
         deactivateButton.setOnClickListener { ForwardingService.deactivate(this) }
+        clearButton.setOnClickListener { clearSchedule() }
 
         requestPermissionsIfNeeded()
         loadScheduledData()
@@ -143,6 +145,17 @@ class MainActivity : AppCompatActivity() {
             contactName = it
             contactNameTextView.text = it
         }
+        if (ScheduleManager.isEnabled(this)) {
+            intervals.clear()
+            intervals.addAll(ScheduleManager.getIntervals(this))
+            updateIntervalsText()
+        }
+    }
+
+    private fun clearSchedule() {
+        ScheduleManager.cancelSchedule(this)
+        intervals.clear()
+        updateIntervalsText()
     }
 
     private fun requestPermissionsIfNeeded() {

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -10,11 +10,14 @@ import java.util.Calendar
 object ScheduleManager {
     private const val PREFS = "schedules"
     private const val KEY_NUMBER = "number"
+    private const val KEY_NAME = "name"
     private const val KEY_INTERVALS = "intervals"
 
-    fun schedule(context: Context, intervals: List<Interval>, number: String) {
+    fun schedule(context: Context, intervals: List<Interval>, number: String, name: String) {
         val prefs = prefs(context)
-        prefs.edit().putString(KEY_NUMBER, number)
+        prefs.edit()
+            .putString(KEY_NUMBER, number)
+            .putString(KEY_NAME, name)
             .putString(KEY_INTERVALS, serialize(intervals))
             .apply()
         intervals.forEachIndexed { index, interval ->
@@ -48,6 +51,12 @@ object ScheduleManager {
             setAlarm(context, interval.end.timeInMillis, false, number, index)
         }
     }
+
+    fun getScheduledNumber(context: Context): String? =
+        prefs(context).getString(KEY_NUMBER, null)
+
+    fun getScheduledName(context: Context): String? =
+        prefs(context).getString(KEY_NAME, null)
 
     private fun serialize(intervals: List<Interval>): String =
         intervals.joinToString(";") { "${it.start.timeInMillis},${it.end.timeInMillis}" }

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -14,6 +14,7 @@ object ScheduleManager {
     private const val KEY_INTERVALS = "intervals"
 
     fun schedule(context: Context, intervals: List<Interval>, number: String, name: String) {
+        cancelAlarms(context)
         val prefs = prefs(context)
         prefs.edit()
             .putString(KEY_NUMBER, number)
@@ -49,6 +50,29 @@ object ScheduleManager {
         intervals.forEachIndexed { index, interval ->
             setAlarm(context, interval.start.timeInMillis, true, number, index)
             setAlarm(context, interval.end.timeInMillis, false, number, index)
+        }
+    }
+
+    private fun cancelAlarms(context: Context) {
+        val prefs = prefs(context)
+        val number = prefs.getString(KEY_NUMBER, null) ?: return
+        val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
+        val intervals = deserialize(serialized)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        intervals.forEachIndexed { index, _ ->
+            listOf(true, false).forEach { activate ->
+                val intent = Intent(context, AlarmReceiver::class.java).apply {
+                    action = if (activate) AlarmReceiver.ACTION_ACTIVATE else AlarmReceiver.ACTION_DEACTIVATE
+                    putExtra(AlarmReceiver.EXTRA_NUMBER, number)
+                }
+                val pending = PendingIntent.getBroadcast(
+                    context,
+                    index * 2 + if (activate) 1 else 0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                alarmManager.cancel(pending)
+            }
         }
     }
 

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -9,23 +9,18 @@ import java.util.Calendar
 
 object ScheduleManager {
     private const val PREFS = "schedules"
-    private const val KEY_NUMBER = "number"
-    private const val KEY_NAME = "name"
     private const val KEY_INTERVALS = "intervals"
     private const val KEY_ENABLED = "enabled"
 
-    fun schedule(context: Context, intervals: List<Interval>, number: String, name: String) {
+    fun schedule(context: Context, intervals: List<Interval>) {
         cancelAlarms(context)
-        val prefs = prefs(context)
-        prefs.edit()
-            .putString(KEY_NUMBER, number)
-            .putString(KEY_NAME, name)
+        prefs(context).edit()
             .putString(KEY_INTERVALS, serialize(intervals))
             .putBoolean(KEY_ENABLED, true)
             .apply()
         intervals.forEachIndexed { index, interval ->
-            setAlarm(context, interval.start.timeInMillis, true, number, index)
-            setAlarm(context, interval.end.timeInMillis, false, number, index)
+            setAlarm(context, interval.start.timeInMillis, true, interval.number, index)
+            setAlarm(context, interval.end.timeInMillis, false, interval.number, index)
         }
     }
 
@@ -47,26 +42,24 @@ object ScheduleManager {
     fun restoreAlarms(context: Context) {
         val prefs = prefs(context)
         if (!prefs.getBoolean(KEY_ENABLED, false)) return
-        val number = prefs.getString(KEY_NUMBER, null) ?: return
         val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
         val intervals = deserialize(serialized)
         intervals.forEachIndexed { index, interval ->
-            setAlarm(context, interval.start.timeInMillis, true, number, index)
-            setAlarm(context, interval.end.timeInMillis, false, number, index)
+            setAlarm(context, interval.start.timeInMillis, true, interval.number, index)
+            setAlarm(context, interval.end.timeInMillis, false, interval.number, index)
         }
     }
 
     private fun cancelAlarms(context: Context) {
         val prefs = prefs(context)
-        val number = prefs.getString(KEY_NUMBER, null) ?: return
         val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
         val intervals = deserialize(serialized)
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        intervals.forEachIndexed { index, _ ->
+        intervals.forEachIndexed { index, interval ->
             listOf(true, false).forEach { activate ->
                 val intent = Intent(context, AlarmReceiver::class.java).apply {
                     action = if (activate) AlarmReceiver.ACTION_ACTIVATE else AlarmReceiver.ACTION_DEACTIVATE
-                    putExtra(AlarmReceiver.EXTRA_NUMBER, number)
+                    putExtra(AlarmReceiver.EXTRA_NUMBER, interval.number)
                 }
                 val pending = PendingIntent.getBroadcast(
                     context,
@@ -81,14 +74,11 @@ object ScheduleManager {
 
     fun cancelSchedule(context: Context) {
         cancelAlarms(context)
-        prefs(context).edit().putBoolean(KEY_ENABLED, false).apply()
+        prefs(context).edit()
+            .remove(KEY_INTERVALS)
+            .putBoolean(KEY_ENABLED, false)
+            .apply()
     }
-
-    fun getScheduledNumber(context: Context): String? =
-        prefs(context).getString(KEY_NUMBER, null)
-
-    fun getScheduledName(context: Context): String? =
-        prefs(context).getString(KEY_NAME, null)
 
     fun isEnabled(context: Context): Boolean =
         prefs(context).getBoolean(KEY_ENABLED, false)
@@ -98,18 +88,32 @@ object ScheduleManager {
         return deserialize(data)
     }
 
-    private fun serialize(intervals: List<Interval>): String =
-        intervals.joinToString(";") { "${it.start.timeInMillis},${it.end.timeInMillis}" }
-
-    private fun deserialize(data: String): List<Interval> =
-        data.split(';').mapNotNull { part ->
-            val pieces = part.split(',')
-            if (pieces.size == 2) {
-                val start = Calendar.getInstance().apply { timeInMillis = pieces[0].toLong() }
-                val end = Calendar.getInstance().apply { timeInMillis = pieces[1].toLong() }
-                Interval(start, end)
-            } else null
+    private fun serialize(intervals: List<Interval>): String {
+        val arr = org.json.JSONArray()
+        intervals.forEach { interval ->
+            val obj = org.json.JSONObject()
+            obj.put("s", interval.start.timeInMillis)
+            obj.put("e", interval.end.timeInMillis)
+            obj.put("n", interval.number)
+            obj.put("name", interval.name)
+            arr.put(obj)
         }
+        return arr.toString()
+    }
+
+    private fun deserialize(data: String): List<Interval> {
+        val arr = org.json.JSONArray(data)
+        val list = mutableListOf<Interval>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val start = Calendar.getInstance().apply { timeInMillis = obj.getLong("s") }
+            val end = Calendar.getInstance().apply { timeInMillis = obj.getLong("e") }
+            val number = obj.getString("n")
+            val name = obj.getString("name")
+            list.add(Interval(start, end, number, name))
+        }
+        return list
+    }
 
     private fun prefs(context: Context): SharedPreferences =
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -1,0 +1,67 @@
+package com.example.reperibilita
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import java.util.Calendar
+
+object ScheduleManager {
+    private const val PREFS = "schedules"
+    private const val KEY_NUMBER = "number"
+    private const val KEY_INTERVALS = "intervals"
+
+    fun schedule(context: Context, intervals: List<Interval>, number: String) {
+        val prefs = prefs(context)
+        prefs.edit().putString(KEY_NUMBER, number)
+            .putString(KEY_INTERVALS, serialize(intervals))
+            .apply()
+        intervals.forEachIndexed { index, interval ->
+            setAlarm(context, interval.start.timeInMillis, true, number, index)
+            setAlarm(context, interval.end.timeInMillis, false, number, index)
+        }
+    }
+
+    private fun setAlarm(context: Context, timeMillis: Long, activate: Boolean, number: String, id: Int) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, AlarmReceiver::class.java).apply {
+            action = if (activate) AlarmReceiver.ACTION_ACTIVATE else AlarmReceiver.ACTION_DEACTIVATE
+            putExtra(AlarmReceiver.EXTRA_NUMBER, number)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            id * 2 + if (activate) 1 else 0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timeMillis, pending)
+    }
+
+    fun restoreAlarms(context: Context) {
+        val prefs = prefs(context)
+        val number = prefs.getString(KEY_NUMBER, null) ?: return
+        val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
+        val intervals = deserialize(serialized)
+        intervals.forEachIndexed { index, interval ->
+            setAlarm(context, interval.start.timeInMillis, true, number, index)
+            setAlarm(context, interval.end.timeInMillis, false, number, index)
+        }
+    }
+
+    private fun serialize(intervals: List<Interval>): String =
+        intervals.joinToString(";") { "${it.start.timeInMillis},${it.end.timeInMillis}" }
+
+    private fun deserialize(data: String): List<Interval> =
+        data.split(';').mapNotNull { part ->
+            val pieces = part.split(',')
+            if (pieces.size == 2) {
+                val start = Calendar.getInstance().apply { timeInMillis = pieces[0].toLong() }
+                val end = Calendar.getInstance().apply { timeInMillis = pieces[1].toLong() }
+                Interval(start, end)
+            } else null
+        }
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -12,6 +12,7 @@ object ScheduleManager {
     private const val KEY_NUMBER = "number"
     private const val KEY_NAME = "name"
     private const val KEY_INTERVALS = "intervals"
+    private const val KEY_ENABLED = "enabled"
 
     fun schedule(context: Context, intervals: List<Interval>, number: String, name: String) {
         cancelAlarms(context)
@@ -20,6 +21,7 @@ object ScheduleManager {
             .putString(KEY_NUMBER, number)
             .putString(KEY_NAME, name)
             .putString(KEY_INTERVALS, serialize(intervals))
+            .putBoolean(KEY_ENABLED, true)
             .apply()
         intervals.forEachIndexed { index, interval ->
             setAlarm(context, interval.start.timeInMillis, true, number, index)
@@ -44,6 +46,7 @@ object ScheduleManager {
 
     fun restoreAlarms(context: Context) {
         val prefs = prefs(context)
+        if (!prefs.getBoolean(KEY_ENABLED, false)) return
         val number = prefs.getString(KEY_NUMBER, null) ?: return
         val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
         val intervals = deserialize(serialized)
@@ -76,11 +79,24 @@ object ScheduleManager {
         }
     }
 
+    fun cancelSchedule(context: Context) {
+        cancelAlarms(context)
+        prefs(context).edit().putBoolean(KEY_ENABLED, false).apply()
+    }
+
     fun getScheduledNumber(context: Context): String? =
         prefs(context).getString(KEY_NUMBER, null)
 
     fun getScheduledName(context: Context): String? =
         prefs(context).getString(KEY_NAME, null)
+
+    fun isEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_ENABLED, false)
+
+    fun getIntervals(context: Context): List<Interval> {
+        val data = prefs(context).getString(KEY_INTERVALS, null) ?: return emptyList()
+        return deserialize(data)
+    }
 
     private fun serialize(intervals: List<Interval>): String =
         intervals.joinToString(";") { "${it.start.timeInMillis},${it.end.timeInMillis}" }

--- a/Reperibilita/app/src/main/res/layout/activity_main.xml
+++ b/Reperibilita/app/src/main/res/layout/activity_main.xml
@@ -66,5 +66,11 @@
         android:layout_height="wrap_content"
         android:text="@string/deactivate" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/clearScheduleButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/clear_schedule" />
+
     </LinearLayout>
 </ScrollView>

--- a/Reperibilita/app/src/main/res/layout/activity_main.xml
+++ b/Reperibilita/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/phoneInputLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/phone_number"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/phoneEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="phone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/selectContactButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/select_contact"
+        app:layout_constraintTop_toBottomOf="@id/phoneInputLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/addIntervalButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/add_interval"
+        app:layout_constraintTop_toBottomOf="@id/selectContactButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/intervalsTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/addIntervalButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/scheduleButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/schedule"
+        app:layout_constraintTop_toBottomOf="@id/intervalsTextView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/activateButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/activate"
+        app:layout_constraintTop_toBottomOf="@id/scheduleButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/deactivateButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/deactivate"
+        app:layout_constraintTop_toBottomOf="@id/activateButton"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Reperibilita/app/src/main/res/layout/activity_main.xml
+++ b/Reperibilita/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="16dp">
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/phoneInputLayout"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/phone_number"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        android:hint="@string/phone_number">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/phoneEditText"
@@ -23,67 +25,46 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/selectContactButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/select_contact"
-        app:layout_constraintTop_toBottomOf="@id/phoneInputLayout"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/select_contact" />
 
     <TextView
         android:id="@+id/contactNameTextView"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
-        android:text="@string/no_contact"
-        app:layout_constraintTop_toBottomOf="@id/selectContactButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/no_contact" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/addIntervalButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/add_interval"
-        app:layout_constraintTop_toBottomOf="@id/contactNameTextView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/add_interval" />
 
     <TextView
         android:id="@+id/intervalsTextView"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp"
-        app:layout_constraintTop_toBottomOf="@id/addIntervalButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:paddingTop="8dp" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/scheduleButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/schedule"
-        app:layout_constraintTop_toBottomOf="@id/intervalsTextView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/schedule" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/activateButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/activate"
-        app:layout_constraintTop_toBottomOf="@id/scheduleButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/activate" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/deactivateButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/deactivate"
-        app:layout_constraintTop_toBottomOf="@id/activateButton"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:text="@string/deactivate" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+</ScrollView>

--- a/Reperibilita/app/src/main/res/layout/activity_main.xml
+++ b/Reperibilita/app/src/main/res/layout/activity_main.xml
@@ -30,12 +30,22 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/contactNameTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/no_contact"
+        app:layout_constraintTop_toBottomOf="@id/selectContactButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/addIntervalButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/add_interval"
-        app:layout_constraintTop_toBottomOf="@id/selectContactButton"
+        app:layout_constraintTop_toBottomOf="@id/contactNameTextView"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/Reperibilita/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Reperibilita/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:fillColor="#FF0000" android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/Reperibilita/app/src/main/res/values/colors.xml
+++ b/Reperibilita/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="white">#FFFFFF</color>
+    <color name="black">#000000</color>
+</resources>

--- a/Reperibilita/app/src/main/res/values/strings.xml
+++ b/Reperibilita/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="select_end_time">Ora di fine</string>
     <string name="select_start_date">Data di inizio</string>
     <string name="select_end_date">Data di fine</string>
+    <string name="clear_schedule">Annulla Programmazione</string>
 </resources>

--- a/Reperibilita/app/src/main/res/values/strings.xml
+++ b/Reperibilita/app/src/main/res/values/strings.xml
@@ -1,0 +1,13 @@
+<resources>
+    <string name="app_name">Reperibilità</string>
+    <string name="select_contact">Seleziona Contatto</string>
+    <string name="add_interval">Aggiungi Fascia</string>
+    <string name="activate">Attiva Inoltro</string>
+    <string name="deactivate">Disattiva Inoltro</string>
+    <string name="schedule">Programma</string>
+    <string name="phone_number">Numero</string>
+    <string name="select_start_time">Ora di inizio</string>
+    <string name="select_end_time">Ora di fine</string>
+    <string name="select_start_date">Data di inizio</string>
+    <string name="select_end_date">Data di fine</string>
+</resources>

--- a/Reperibilita/app/src/main/res/values/strings.xml
+++ b/Reperibilita/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="deactivate">Disattiva Inoltro</string>
     <string name="schedule">Programma</string>
     <string name="phone_number">Numero</string>
+    <string name="no_contact">Nessun contatto selezionato</string>
     <string name="select_start_time">Ora di inizio</string>
     <string name="select_end_time">Ora di fine</string>
     <string name="select_start_date">Data di inizio</string>

--- a/Reperibilita/app/src/main/res/values/themes.xml
+++ b/Reperibilita/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Reperibilita" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+    </style>
+</resources>

--- a/Reperibilita/build.gradle
+++ b/Reperibilita/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.4.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
+    }
+}
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/Reperibilita/gradle/wrapper/gradle-wrapper.properties
+++ b/Reperibilita/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/Reperibilita/gradlew
+++ b/Reperibilita/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+DIR="$(dirname "$0")"
+exec gradle --project-dir "$DIR" "$@"

--- a/Reperibilita/settings.gradle
+++ b/Reperibilita/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Reperibilita"
+include(":app")


### PR DESCRIPTION
## Summary
- allow picking start/end dates in `MainActivity`
- show full date and time in `Interval` string
- target Android 11 API level
- document date/time scheduling in README

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684044280ff483218cc953c47d3823fb