### PR TITLE
Improve background scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Gradle build output
+**/build/
+# Ignore local Gradle settings
+.gradle/
+local.properties

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Reperibilita
+
+Questo repository contiene una semplice app Android (Kotlin) per programmare l'inoltro di chiamata sul proprio telefono.
+
+La funzionalità principale prevede l'attivazione tramite il codice `**21*+39[numerodidestinazione]#` e la disattivazione con `##002#`. Dall'app è possibile scegliere il numero dalla rubrica e programmare l'inoltro definendo intervalli con data e ora di inizio e fine.
+Quando arriva l'ora programmata viene avviato un servizio in foreground con notifica permanente che esegue il codice USSD. A causa delle limitazioni di Android 11 l'operazione richiede l'apertura automatica del dialer tramite `ACTION_CALL` e può necessitare la conferma dell'utente.
+Ogni fascia salvata mostra il nome del contatto scelto così da sapere a chi è indirizzata. È possibile inserire più contatti e numeri durante la giornata, programmando diverse fasce orarie.
+Gli allarmi vengono impostati con `AlarmManager.setExactAndAllowWhileIdle` per funzionare anche con il telefono bloccato e in modalità doze.
+Il servizio resta in esecuzione per tutta la durata dell'inoltro mostrando la notifica, così da non essere terminato dal sistema, e viene ripristinato automaticamente al riavvio.
+Se due fasce sono consecutive (l'ora di fine della prima coincide con quella di inizio della successiva) la prima non invia il comando di disattivazione `##002#`, ma l'app passa direttamente al nuovo numero programmato.
+L'interfaccia utilizza componenti Material per una presentazione chiara degli intervalli programmati.
+
+## Build dell'APK
+Per compilare è necessario avere installato l'SDK Android.
+Se Android Studio non individua automaticamente il percorso, create nella radice
+della cartella `Reperibilita` un file `local.properties` con il seguente
+contenuto indicando il percorso del vostro SDK:
+
+```
+sdk.dir=C:\\Percorso\\Android\\sdk
+```
+
+Una volta configurato l'SDK potete compilare usando:
+
+```bash
+cd Reperibilita
+./gradlew assembleDebug
+```
+
+Il file APK verrà generato in `app/build/outputs/apk/debug/`. Copiatelo sul dispositivo e installatelo per effettuare i test.
+
+L'interfaccia permette di selezionare un contatto e aggiungere più intervalli. Per ogni intervallo vengono scelti una data e un'orario di inizio e di fine tramite i relativi selettori. Una volta programmati, gli allarmi vengono ripristinati automaticamente al riavvio del telefono.
+
+È presente inoltre un pulsante "Annulla Programmazione" che rimuove tutte le fasce orarie salvate. Al primo avvio l'app richiede di essere esclusa dalle ottimizzazioni batteria tramite l'apposita schermata di sistema; in questo modo il servizio in foreground potrà continuare a funzionare anche con lo schermo bloccato.

--- a/Reperibilita/app/build.gradle
+++ b/Reperibilita/app/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.reperibilita"
+        minSdk 23
+        targetSdk 30
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
+}

--- a/Reperibilita/app/proguard-rules.pro
+++ b/Reperibilita/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for Reperibilita

--- a/Reperibilita/app/src/main/AndroidManifest.xml
+++ b/Reperibilita/app/src/main/AndroidManifest.xml
@@ -1,0 +1,32 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.reperibilita">
+
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="Reperibilità"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Reperibilita">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <receiver android:name=".BootReceiver" android:exported="false" >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <receiver android:name=".AlarmReceiver" android:exported="false" />
+        <service android:name=".ForwardingService"
+            android:foregroundServiceType="phoneCall"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/AlarmReceiver.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/AlarmReceiver.kt
@@ -1,0 +1,25 @@
+package com.example.reperibilita
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_ACTIVATE -> {
+                val number = intent.getStringExtra(EXTRA_NUMBER) ?: return
+                ForwardingService.activate(context, number)
+            }
+            ACTION_DEACTIVATE -> {
+                ForwardingService.deactivate(context)
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_ACTIVATE = "com.example.reperibilita.ACTIVATE"
+        const val ACTION_DEACTIVATE = "com.example.reperibilita.DEACTIVATE"
+        const val EXTRA_NUMBER = "extra_number"
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/BootReceiver.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/BootReceiver.kt
@@ -1,0 +1,13 @@
+package com.example.reperibilita
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            ScheduleManager.restoreAlarms(context)
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ForwardingService.kt
@@ -1,0 +1,90 @@
+package com.example.reperibilita
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class ForwardingService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_ACTIVATE -> {
+                val phoneNumber = intent.getStringExtra(EXTRA_NUMBER) ?: return START_NOT_STICKY
+                startForeground(NOTIFICATION_ID, createNotification(phoneNumber))
+                sendActivationCode(phoneNumber)
+                return START_STICKY
+            }
+            ACTION_DEACTIVATE -> {
+                sendDeactivationCode()
+                stopForeground(true)
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            else -> return START_NOT_STICKY
+        }
+    }
+
+    private fun createNotification(phoneNumber: String): Notification {
+        val channelId = "reperibilita_channel"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Reperibilita", NotificationManager.IMPORTANCE_LOW)
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+        val intent = Intent(this, MainActivity::class.java)
+        val pending = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle("Reperibilità attiva")
+            .setContentText("Inoltro verso $phoneNumber")
+            .setSmallIcon(android.R.drawable.sym_call_outgoing)
+            .setContentIntent(pending)
+            .build()
+    }
+
+    private fun sendActivationCode(phoneNumber: String) {
+        val ussd = "**21*+39${phoneNumber}#"
+        val uri = Uri.parse("tel:" + Uri.encode(ussd))
+        val intent = Intent(Intent.ACTION_CALL, uri)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+    }
+
+    private fun sendDeactivationCode() {
+        val uri = Uri.parse("tel:%23%23002%23")
+        val intent = Intent(Intent.ACTION_CALL, uri)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 1
+        private const val EXTRA_NUMBER = "extra_number"
+        private const val ACTION_ACTIVATE = "com.example.reperibilita.ACTIVATE_SERVICE"
+        private const val ACTION_DEACTIVATE = "com.example.reperibilita.DEACTIVATE_SERVICE"
+
+        fun activate(context: Context, number: String) {
+            val intent = Intent(context, ForwardingService::class.java).apply {
+                action = ACTION_ACTIVATE
+                putExtra(EXTRA_NUMBER, number)
+            }
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        fun deactivate(context: Context) {
+            val intent = Intent(context, ForwardingService::class.java).apply {
+                action = ACTION_DEACTIVATE
+            }
+            ContextCompat.startForegroundService(context, intent)
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/Interval.kt
@@ -1,0 +1,18 @@
+package com.example.reperibilita
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+data class Interval(
+    val start: Calendar,
+    val end: Calendar,
+    val number: String,
+    val name: String
+) {
+    override fun toString(): String {
+        val fmt = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+        val range = "${fmt.format(start.time)} - ${fmt.format(end.time)}"
+        return "$range → $name"
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/MainActivity.kt
@@ -1,0 +1,187 @@
+package com.example.reperibilita
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import android.os.Build
+import android.content.Context
+import android.provider.ContactsContract
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import android.provider.Settings
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import com.google.android.material.datepicker.MaterialDatePicker
+import java.util.Calendar
+
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var phoneEditText: EditText
+    private lateinit var contactNameTextView: TextView
+    private lateinit var intervalsTextView: TextView
+    private val intervals = mutableListOf<Interval>()
+    private var contactName: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        phoneEditText = findViewById(R.id.phoneEditText)
+        intervalsTextView = findViewById(R.id.intervalsTextView)
+        contactNameTextView = findViewById(R.id.contactNameTextView)
+        val selectContactButton: Button = findViewById(R.id.selectContactButton)
+        val addIntervalButton: Button = findViewById(R.id.addIntervalButton)
+        val scheduleButton: Button = findViewById(R.id.scheduleButton)
+        val activateButton: Button = findViewById(R.id.activateButton)
+        val deactivateButton: Button = findViewById(R.id.deactivateButton)
+        val clearButton: Button = findViewById(R.id.clearScheduleButton)
+
+        selectContactButton.setOnClickListener { pickContact() }
+        addIntervalButton.setOnClickListener { addInterval() }
+        scheduleButton.setOnClickListener { schedule() }
+        activateButton.setOnClickListener { ForwardingService.activate(this, phoneEditText.text.toString()) }
+        deactivateButton.setOnClickListener { ForwardingService.deactivate(this) }
+        clearButton.setOnClickListener { clearSchedule() }
+
+        requestPermissionsIfNeeded()
+        requestIgnoreBatteryOptimizations()
+        loadScheduledData()
+    }
+
+    private fun pickContact() {
+        val intent = Intent(Intent.ACTION_PICK, ContactsContract.CommonDataKinds.Phone.CONTENT_URI)
+        contactResultLauncher.launch(intent)
+    }
+
+    private val contactResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.data?.let { uri ->
+                queryContact(uri)
+            }
+        }
+    }
+
+    private fun queryContact(uri: Uri) {
+        val cursor = contentResolver.query(
+            uri,
+            arrayOf(
+                ContactsContract.CommonDataKinds.Phone.NUMBER,
+                ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME
+            ),
+            null,
+            null,
+            null
+        )
+        cursor?.use {
+            if (it.moveToFirst()) {
+                val number = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+                val name = it.getString(it.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME))
+                phoneEditText.setText(number)
+                contactNameTextView.text = name
+                contactName = name
+            }
+        }
+    }
+
+    private fun addInterval() {
+        val startDatePicker = MaterialDatePicker.Builder.datePicker()
+            .setTitleText(getString(R.string.select_start_date))
+            .build()
+        startDatePicker.addOnPositiveButtonClickListener { startMillis ->
+            val start = Calendar.getInstance().apply { timeInMillis = startMillis }
+            val startTimePicker = MaterialTimePicker.Builder()
+                .setTimeFormat(TimeFormat.CLOCK_24H)
+                .setTitleText(getString(R.string.select_start_time))
+                .build()
+            startTimePicker.addOnPositiveButtonClickListener {
+                start.set(Calendar.HOUR_OF_DAY, startTimePicker.hour)
+                start.set(Calendar.MINUTE, startTimePicker.minute)
+
+                val endDatePicker = MaterialDatePicker.Builder.datePicker()
+                    .setTitleText(getString(R.string.select_end_date))
+                    .build()
+                endDatePicker.addOnPositiveButtonClickListener { endMillis ->
+                    val end = Calendar.getInstance().apply { timeInMillis = endMillis }
+                    val endTimePicker = MaterialTimePicker.Builder()
+                        .setTimeFormat(TimeFormat.CLOCK_24H)
+                        .setTitleText(getString(R.string.select_end_time))
+                        .build()
+                    endTimePicker.addOnPositiveButtonClickListener {
+                        end.set(Calendar.HOUR_OF_DAY, endTimePicker.hour)
+                        end.set(Calendar.MINUTE, endTimePicker.minute)
+                        val number = phoneEditText.text.toString()
+                        if (number.isNotBlank()) {
+                            intervals.add(Interval(start, end, number, contactName))
+                            updateIntervalsText()
+                        }
+                    }
+                    endTimePicker.show(supportFragmentManager, "end_time")
+                }
+                endDatePicker.show(supportFragmentManager, "end_date")
+            }
+            startTimePicker.show(supportFragmentManager, "start_time")
+        }
+        startDatePicker.show(supportFragmentManager, "start_date")
+    }
+
+    private fun updateIntervalsText() {
+        intervalsTextView.text = intervals.joinToString("\n") {
+            "\u2022 ${it} (${it.number})"
+        }
+    }
+
+    private fun schedule() {
+        if (intervals.isNotEmpty()) {
+            ScheduleManager.schedule(this, intervals)
+        }
+    }
+
+    private fun loadScheduledData() {
+        if (ScheduleManager.isEnabled(this)) {
+            intervals.clear()
+            intervals.addAll(ScheduleManager.getIntervals(this))
+            updateIntervalsText()
+        }
+    }
+
+    private fun clearSchedule() {
+        ScheduleManager.cancelSchedule(this)
+        intervals.clear()
+        updateIntervalsText()
+    }
+
+    private fun requestPermissionsIfNeeded() {
+        val permissions = arrayOf(
+            Manifest.permission.CALL_PHONE,
+            Manifest.permission.READ_CONTACTS
+        )
+        val toRequest = permissions.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (toRequest.isNotEmpty()) {
+            ActivityCompat.requestPermissions(this, toRequest.toTypedArray(), 0)
+        }
+    }
+
+    private fun requestIgnoreBatteryOptimizations() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val pm = getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
+            if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+                val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                    Uri.parse("package:$packageName"))
+                startActivity(intent)
+            }
+        }
+    }
+}

--- a/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
+++ b/Reperibilita/app/src/main/java/com/example/reperibilita/ScheduleManager.kt
@@ -1,0 +1,127 @@
+package com.example.reperibilita
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import java.util.Calendar
+
+object ScheduleManager {
+    private const val PREFS = "schedules"
+    private const val KEY_INTERVALS = "intervals"
+    private const val KEY_ENABLED = "enabled"
+
+    fun schedule(context: Context, intervals: List<Interval>) {
+        cancelAlarms(context)
+        val sorted = intervals.sortedBy { it.start.timeInMillis }
+        prefs(context).edit()
+            .putString(KEY_INTERVALS, serialize(sorted))
+            .putBoolean(KEY_ENABLED, true)
+            .apply()
+        sorted.forEachIndexed { index, interval ->
+            setAlarm(context, interval.start.timeInMillis, true, interval.number, index)
+            val nextStartSame = sorted.getOrNull(index + 1)?.start?.timeInMillis == interval.end.timeInMillis
+            if (!nextStartSame) {
+                setAlarm(context, interval.end.timeInMillis, false, interval.number, index)
+            }
+        }
+    }
+
+    private fun setAlarm(context: Context, timeMillis: Long, activate: Boolean, number: String, id: Int) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, AlarmReceiver::class.java).apply {
+            action = if (activate) AlarmReceiver.ACTION_ACTIVATE else AlarmReceiver.ACTION_DEACTIVATE
+            putExtra(AlarmReceiver.EXTRA_NUMBER, number)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            id * 2 + if (activate) 1 else 0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timeMillis, pending)
+    }
+
+    fun restoreAlarms(context: Context) {
+        val prefs = prefs(context)
+        if (!prefs.getBoolean(KEY_ENABLED, false)) return
+        val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
+        val intervals = deserialize(serialized).sortedBy { it.start.timeInMillis }
+        intervals.forEachIndexed { index, interval ->
+            setAlarm(context, interval.start.timeInMillis, true, interval.number, index)
+            val nextStartSame = intervals.getOrNull(index + 1)?.start?.timeInMillis == interval.end.timeInMillis
+            if (!nextStartSame) {
+                setAlarm(context, interval.end.timeInMillis, false, interval.number, index)
+            }
+        }
+    }
+
+    private fun cancelAlarms(context: Context) {
+        val prefs = prefs(context)
+        val serialized = prefs.getString(KEY_INTERVALS, null) ?: return
+        val intervals = deserialize(serialized)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        intervals.forEachIndexed { index, interval ->
+            listOf(true, false).forEach { activate ->
+                val intent = Intent(context, AlarmReceiver::class.java).apply {
+                    action = if (activate) AlarmReceiver.ACTION_ACTIVATE else AlarmReceiver.ACTION_DEACTIVATE
+                    putExtra(AlarmReceiver.EXTRA_NUMBER, interval.number)
+                }
+                val pending = PendingIntent.getBroadcast(
+                    context,
+                    index * 2 + if (activate) 1 else 0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                alarmManager.cancel(pending)
+            }
+        }
+    }
+
+    fun cancelSchedule(context: Context) {
+        cancelAlarms(context)
+        prefs(context).edit()
+            .remove(KEY_INTERVALS)
+            .putBoolean(KEY_ENABLED, false)
+            .apply()
+    }
+
+    fun isEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_ENABLED, false)
+
+    fun getIntervals(context: Context): List<Interval> {
+        val data = prefs(context).getString(KEY_INTERVALS, null) ?: return emptyList()
+        return deserialize(data).sortedBy { it.start.timeInMillis }
+    }
+
+    private fun serialize(intervals: List<Interval>): String {
+        val arr = org.json.JSONArray()
+        intervals.forEach { interval ->
+            val obj = org.json.JSONObject()
+            obj.put("s", interval.start.timeInMillis)
+            obj.put("e", interval.end.timeInMillis)
+            obj.put("n", interval.number)
+            obj.put("name", interval.name)
+            arr.put(obj)
+        }
+        return arr.toString()
+    }
+
+    private fun deserialize(data: String): List<Interval> {
+        val arr = org.json.JSONArray(data)
+        val list = mutableListOf<Interval>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val start = Calendar.getInstance().apply { timeInMillis = obj.getLong("s") }
+            val end = Calendar.getInstance().apply { timeInMillis = obj.getLong("e") }
+            val number = obj.getString("n")
+            val name = obj.getString("name")
+            list.add(Interval(start, end, number, name))
+        }
+        return list
+    }
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/Reperibilita/app/src/main/res/layout/activity_main.xml
+++ b/Reperibilita/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/phoneInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/phone_number">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/phoneEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="phone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/selectContactButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/select_contact" />
+
+    <TextView
+        android:id="@+id/contactNameTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/no_contact" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/addIntervalButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/add_interval" />
+
+    <TextView
+        android:id="@+id/intervalsTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/scheduleButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/schedule" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/activateButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/activate" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/deactivateButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/deactivate" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/clearScheduleButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/clear_schedule" />
+
+    </LinearLayout>
+</ScrollView>

--- a/Reperibilita/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Reperibilita/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:fillColor="#FF0000" android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/Reperibilita/app/src/main/res/values/colors.xml
+++ b/Reperibilita/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="white">#FFFFFF</color>
+    <color name="black">#000000</color>
+</resources>

--- a/Reperibilita/app/src/main/res/values/strings.xml
+++ b/Reperibilita/app/src/main/res/values/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+    <string name="app_name">Reperibilità</string>
+    <string name="select_contact">Seleziona Contatto</string>
+    <string name="add_interval">Aggiungi Fascia</string>
+    <string name="activate">Attiva Inoltro</string>
+    <string name="deactivate">Disattiva Inoltro</string>
+    <string name="schedule">Programma</string>
+    <string name="phone_number">Numero</string>
+    <string name="no_contact">Nessun contatto selezionato</string>
+    <string name="select_start_time">Ora di inizio</string>
+    <string name="select_end_time">Ora di fine</string>
+    <string name="select_start_date">Data di inizio</string>
+    <string name="select_end_date">Data di fine</string>
+    <string name="clear_schedule">Annulla Programmazione</string>
+</resources>

--- a/Reperibilita/app/src/main/res/values/themes.xml
+++ b/Reperibilita/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Reperibilita" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+    </style>
+</resources>

--- a/Reperibilita/build.gradle
+++ b/Reperibilita/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.4.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
+    }
+}
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/Reperibilita/gradle/wrapper/gradle-wrapper.properties
+++ b/Reperibilita/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/Reperibilita/gradlew
+++ b/Reperibilita/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+DIR="$(dirname "$0")"
+exec gradle --project-dir "$DIR" "$@"

--- a/Reperibilita/settings.gradle
+++ b/Reperibilita/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Reperibilita"
+include(":app")


### PR DESCRIPTION
## Summary
- keep call forwarding service running until deactivation
- request battery optimization exemption
- avoid disabling forwarding between back-to-back intervals
- document the new behaviour in README

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684044280ff483218cc953c47d3823fb